### PR TITLE
Improve license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,3 @@
-Copyright (C) 2008 Bart Massey
-ALL RIGHTS RESERVED
-
-[This program is licensed under the GPL version 3 or later.]
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/page-mode.el
+++ b/page-mode.el
@@ -1,11 +1,19 @@
 ;;; page-mode.el --- Limit visibility to a page
 
 ;; Copyright (C) 2008 Bart Massey
-;; ALL RIGHTS RESERVED
-;; 
-;; [This program is licensed under the GPL version 3 or later.]
-;; Please see the file COPYING in the source
-;; distribution of this software for license terms.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 


### PR DESCRIPTION
* Rename COPYING to LICENSE, which is more common nowadays and is
  more explicit about what text to expect in there.
* Remove some text previously added to the front of the license text.
  That helps tools that try to automatically detect what license is
  being used.
* Add the standard permission statement to the library header.